### PR TITLE
Fix a bug and simplify pom.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MeteoInfo Class Library
 2. build and install [wContour](https://github.com/Anebrithien/wContour) to your local maven repo
 
 3. cd to project root directory, run `mvn install -Dmaven.test.skip=true`, 
-then get jar file `meteoInfoLib-0.0.1-SNAPSHOT.jar` in `target/`
+then get jar file `meteoInfoLib-0.0.2-SNAPSHOT.jar` in `target/`
 
 4. use this in your maven projects
 
@@ -17,7 +17,7 @@ then get jar file `meteoInfoLib-0.0.1-SNAPSHOT.jar` in `target/`
   <dependency>
     <groupId>org.meteothinker</groupId>
     <artifactId>meteoInfoLib</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
   </dependency>
   ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.meteothinker</groupId>
   <artifactId>meteoInfoLib</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
 
@@ -37,7 +37,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.7</java.version>
-    <jodatime.version>2.2</jodatime.version>
+    <jodatime.version>2.10</jodatime.version>
     <netcdfAll.version>4.6.11</netcdfAll.version>
     <grib.version>4.5.5</grib.version>
     <jcalendar.version>1.4</jcalendar.version>
@@ -100,6 +100,16 @@
       <groupId>edu.ucar</groupId>
       <artifactId>grib</artifactId>
       <version>${grib.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-api</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>joda-time</artifactId>
+          <groupId>joda-time</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.scilab.forge</groupId>
@@ -109,11 +119,6 @@
     <dependency>
       <groupId>org.freehep</groupId>
       <artifactId>freehep-graphics2d</artifactId>
-      <version>${freehep.graphics.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.freehep</groupId>
-      <artifactId>freehep-graphicsio</artifactId>
       <version>${freehep.graphics.version}</version>
     </dependency>
     <dependency>
@@ -132,16 +137,6 @@
       <version>${freehep.graphics.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
-      <version>${groovy.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.freehep</groupId>
-      <artifactId>freehep-io</artifactId>
-      <version>${freehep.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.freehep</groupId>
       <artifactId>freehep-util</artifactId>
       <version>${freehep.version}</version>
@@ -155,11 +150,6 @@
       <groupId>org.python</groupId>
       <artifactId>jython-standalone</artifactId>
       <version>${jython.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fifesoft</groupId>
-      <artifactId>rsyntaxtextarea</artifactId>
-      <version>${rsyntaxtextarea.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sanselan</groupId>
@@ -183,43 +173,13 @@
     </dependency>
     <dependency>
       <groupId>org.ejml</groupId>
-      <artifactId>ejml-core</artifactId>
-      <version>${ejml.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ejml</groupId>
-      <artifactId>ejml-cdense</artifactId>
-      <version>${ejml.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ejml</groupId>
-      <artifactId>ejml-ddense</artifactId>
-      <version>${ejml.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ejml</groupId>
-      <artifactId>ejml-dsparse</artifactId>
-      <version>${ejml.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ejml</groupId>
       <artifactId>ejml-experimental</artifactId>
       <version>${ejml.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ejml</groupId>
-      <artifactId>ejml-fdense</artifactId>
-      <version>${ejml.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ejml</groupId>
       <artifactId>ejml-simple</artifactId>
-      <version>${ejml.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ejml</groupId>
-      <artifactId>ejml-zdense</artifactId>
       <version>${ejml.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,11 +87,6 @@
       <version>${jcalendar.version}</version>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>${jodatime.version}</version>
-    </dependency>
-    <dependency>
       <groupId>edu.ucar</groupId>
       <artifactId>netcdfAll</artifactId>
       <version>${netcdfAll.version}</version>
@@ -155,11 +150,6 @@
       <groupId>org.apache.sanselan</groupId>
       <artifactId>sanselan</artifactId>
       <version>${sanselan.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>com.l2fprod</groupId>

--- a/src/org/meteoinfo/data/meteodata/DrawMeteoData.java
+++ b/src/org/meteoinfo/data/meteodata/DrawMeteoData.java
@@ -847,7 +847,7 @@ public class DrawMeteoData {
                 valueIdx = -valueIdx - 1;
             }
             //valueIdx = Arrays.asList(cValues).indexOf(aValue);            
-            if (valueIdx == cValues.length - 1) {
+            if (valueIdx >= cValues.length - 1) {
                 aPolygonShape.highValue = maxData;
             } else {
                 aPolygonShape.highValue = cValues[valueIdx + 1];


### PR DESCRIPTION
1. Fix an `ArrayIndexOutOfBoundsException` at `org/meteoinfo/data/meteodata/DrawMeteoData.java:850`, the bug was reproduced when `valueIdx > cValues.length - 1`. This fix might be correct, would you like to review this? @Yaqiang 

2. Simplify the maven pom.xml, remove useless dependencies. 

3. Bump the maven artifactId version to `0.0.2-SNAPSHOT`.